### PR TITLE
fix: DB에 몇몇 컬럼 스키마가 enum 타입으로 들어가던 버그 수정

### DIFF
--- a/src/main/java/com/example/kloset_lab/clothes/entity/Clothes.java
+++ b/src/main/java/com/example/kloset_lab/clothes/entity/Clothes.java
@@ -46,7 +46,7 @@ public class Clothes extends BaseTimeEntity {
     private LocalDate boughtDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "category", nullable = false, length = 15)
+    @Column(name = "category", nullable = false, columnDefinition = "varchar(15)")
     private Category category;
 
     @Builder

--- a/src/main/java/com/example/kloset_lab/media/entity/MediaFile.java
+++ b/src/main/java/com/example/kloset_lab/media/entity/MediaFile.java
@@ -23,22 +23,23 @@ public class MediaFile extends BaseTimeEntity {
     private User user;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "purpose", nullable = false, columnDefinition = "varchar(10)")
     private Purpose purpose;
 
-    @Column(name = "object_key")
+    @Column(name = "object_key", nullable = false)
     private String objectKey;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type")
+    @Column(name = "type", nullable = false, columnDefinition = "varchar(10)")
     private FileType fileType;
 
-    @Column(name = "size")
+    @Column(name = "size", nullable = false)
     private Long size;
 
     @Column(name = "uploaded_at")
     private LocalDateTime uploadedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status")
-    private FileStatus status;
+    @Column(name = "status", nullable = false, columnDefinition = "varchar(10)")
+    private FileStatus status = FileStatus.PENDING;
 }

--- a/src/main/java/com/example/kloset_lab/user/entity/User.java
+++ b/src/main/java/com/example/kloset_lab/user/entity/User.java
@@ -27,18 +27,18 @@ public class User extends BaseEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false, length = 10)
+    @Column(name = "role", nullable = false, columnDefinition = "varchar(10)")
     private UserRole role;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "provider", nullable = false, length = 10)
+    @Column(name = "provider", nullable = false, columnDefinition = "varchar(10)")
     private Provider provider;
 
     @Column(name = "provider_id", nullable = false)
     private String providerId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 10)
+    @Column(name = "status", nullable = false, columnDefinition = "varchar(10)")
     private UserStatus status;
 
     @Builder

--- a/src/main/java/com/example/kloset_lab/user/entity/UserProfile.java
+++ b/src/main/java/com/example/kloset_lab/user/entity/UserProfile.java
@@ -44,7 +44,7 @@ public class UserProfile extends BaseTimeEntity {
     private LocalDate birthDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "gender", nullable = false, length = 10)
+    @Column(name = "gender", nullable = false, columnDefinition = "varchar(10)")
     private Gender gender;
 
     @Builder


### PR DESCRIPTION
## 연관된 이슈
#47 [BE] fix: DB에 몇몇 컬럼 스키마가 enum 타입으로 들어가던 버그 수정 


## 작업 내용
- User, UserProfile, Clothes, MediaFile 도메인에서 enum 타입이 DB에 varchar 로 들어가지 않고, enum 타입 그대로 저장되고 있음

  - Spring Boot 3.x 부터는 ENUM 타입 엔티티에 "@ Enumerated(EnumType.STRING)" 를. 붙인다고 DB에서 varchar로 자동변환해주지 않고, enum 타입으로 들어감.
  - @ Column(columnDefinition = "varchar(15)") 처럼 명시적으로 선언하여 해결

## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 