### PR TITLE
refactor: ApiResponses 기반 공통 응답 형식으로 통일

### DIFF
--- a/src/main/java/com/example/kloset_lab/auth/controller/AuthController.java
+++ b/src/main/java/com/example/kloset_lab/auth/controller/AuthController.java
@@ -1,12 +1,14 @@
 package com.example.kloset_lab.auth.controller;
 
 import com.example.kloset_lab.auth.dto.KakaoLoginRequest;
+import com.example.kloset_lab.auth.dto.KakaoLoginResponse;
 import com.example.kloset_lab.auth.dto.TokenRefreshResponse;
 import com.example.kloset_lab.auth.service.AuthService;
 import com.example.kloset_lab.auth.service.AuthService.KakaoLoginResult;
 import com.example.kloset_lab.auth.service.AuthService.TokenRefreshResult;
 import com.example.kloset_lab.global.exception.InvalidTokenException;
 import com.example.kloset_lab.global.response.ApiResponse;
+import com.example.kloset_lab.global.response.ApiResponses;
 import com.example.kloset_lab.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -38,7 +40,7 @@ public class AuthController {
      * - 신규 회원: isRegistered=false, accessToken 반환 (회원가입 추가 정보 입력 필요)
      */
     @PostMapping("/kakao")
-    public ResponseEntity<ApiResponse<?>> kakaoLogin(
+    public ResponseEntity<ApiResponse<KakaoLoginResponse>> kakaoLogin(
             @RequestBody @Valid KakaoLoginRequest request, HttpServletResponse response) {
 
         KakaoLoginResult result = authService.kakaoLogin(request.authorizationCode());
@@ -46,7 +48,7 @@ public class AuthController {
         Optional.ofNullable(result.refreshToken())
                 .ifPresent(token -> CookieUtil.addRefreshTokenCookie(response, token));
 
-        return ResponseEntity.ok(ApiResponse.success(result.response().resultMessage(), result.response()));
+        return ApiResponses.ok(result.response().resultMessage(), result.response());
     }
 
     /**
@@ -67,7 +69,7 @@ public class AuthController {
         // 새 리프레시 토큰을 쿠키에 설정
         CookieUtil.addRefreshTokenCookie(response, result.newRefreshToken());
 
-        return ResponseEntity.ok(ApiResponse.success("accessToken_refreshed", result.response()));
+        return ApiResponses.ok("accessToken_refreshed", result.response());
     }
 
     /**
@@ -83,6 +85,6 @@ public class AuthController {
         // 리프레시 토큰 쿠키 만료 처리
         CookieUtil.expireRefreshTokenCookie(response);
 
-        return ResponseEntity.ok(ApiResponse.success("logout_success"));
+        return ApiResponses.ok("logout_success");
     }
 }

--- a/src/main/java/com/example/kloset_lab/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/kloset_lab/global/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
     FILE_SIZE_EXCEEDS_10MB(HttpStatus.BAD_REQUEST, "file_size_exceeds_10mb"),
 
     // 401 Unauthorized
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "authentication_required"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "invalid_token"),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "access_token_expired"),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "refresh_token_expired"),
 

--- a/src/main/java/com/example/kloset_lab/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kloset_lab/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package com.example.kloset_lab.global.exception;
 import com.example.kloset_lab.global.response.ApiResponse;
 import com.example.kloset_lab.global.response.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,11 +11,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // TODO: CustomException을 사용하도록 수정 필요
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ApiResponse<Void>> handleInvalidTokenException(InvalidTokenException e) {
         log.warn("InvalidTokenException: {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error(401, e.getMessage()));
+        return ApiResponses.error(ErrorCode.INVALID_TOKEN);
     }
 
     @ExceptionHandler(CustomException.class)

--- a/src/main/java/com/example/kloset_lab/global/response/ApiResponse.java
+++ b/src/main/java/com/example/kloset_lab/global/response/ApiResponse.java
@@ -16,19 +16,15 @@ public class ApiResponse<T> {
     private final String message;
     private final T data;
 
-    // TODO: 아래 4개의 메소드 사용 부분 제거 필요, ApiResponses 사용 으로 변경해주세요
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return ApiResponse.<T>builder().code(200).message(message).data(data).build();
-    }
-
-    public static <T> ApiResponse<T> success(int code, String message, T data) {
-        return ApiResponse.<T>builder().code(code).message(message).data(data).build();
-    }
-
-    public static ApiResponse<Void> success(String message) {
-        return ApiResponse.<Void>builder().code(200).message(message).data(null).build();
-    }
-
+    /**
+     * Security Filter용 에러 응답 생성
+     * DispatcherServlet 이전에 동작하는 Security Filter에서는 ResponseEntity를 반환할 수 없으므로
+     * ApiResponse 객체를 직접 생성하여 HttpServletResponse에 작성해야 합니다.
+     *
+     * @param code 에러 코드
+     * @param message 에러 메시지
+     * @return ApiResponse 객체
+     */
     public static <T> ApiResponse<T> error(int code, String message) {
         return ApiResponse.<T>builder().code(code).message(message).data(null).build();
     }

--- a/src/main/java/com/example/kloset_lab/global/security/filter/exceptionHandler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/kloset_lab/global/security/filter/exceptionHandler/CustomAccessDeniedHandler.java
@@ -1,5 +1,6 @@
 package com.example.kloset_lab.global.security.filter.exceptionHandler;
 
+import com.example.kloset_lab.global.exception.ErrorCode;
 import com.example.kloset_lab.global.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
@@ -30,11 +31,12 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
         log.warn("접근 거부: {} - {}", request.getRequestURI(), accessDeniedException.getMessage());
 
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+        response.setStatus(errorCode.getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        ApiResponse<Void> apiResponse = ApiResponse.error(403, "접근 권한이 없습니다.");
+        ApiResponse<Void> apiResponse = ApiResponse.error(errorCode.getStatus().value(), errorCode.getMessage());
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
     }
 }

--- a/src/main/java/com/example/kloset_lab/global/security/filter/exceptionHandler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/kloset_lab/global/security/filter/exceptionHandler/CustomAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package com.example.kloset_lab.global.security.filter.exceptionHandler;
 
+import com.example.kloset_lab.global.exception.ErrorCode;
 import com.example.kloset_lab.global.response.ApiResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
@@ -32,11 +33,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
         log.warn("인증 실패: {} - {}", request.getRequestURI(), authException.getMessage());
 
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        ErrorCode errorCode = ErrorCode.AUTHENTICATION_REQUIRED;
+        response.setStatus(errorCode.getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        ApiResponse<Void> apiResponse = ApiResponse.error(401, "인증이 필요합니다.");
+        ApiResponse<Void> apiResponse = ApiResponse.error(errorCode.getStatus().value(), errorCode.getMessage());
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#49 [BE] refactor: ApiResponses 기반 공통 응답 형식으로 통일


## 작업 내용
- Controller, ExceptionHandler에서 ApiResponses 사용으로 변경
- Security Filter는 ApiResponse.error() 유지 (DispatcherServlet 이전 동작)
- ApiResponse의 success 메서드들 제거
- ErrorCode에 AUTHENTICATION_REQUIRED, INVALID_TOKEN 추가

## 체크리스트
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 