### PR TITLE
fix: PENDING 회원 재진입 시 에러 발생 문제 해결 close #78

### DIFF
--- a/src/main/java/com/example/kloset_lab/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/example/kloset_lab/global/security/config/SecurityConfig.java
@@ -44,7 +44,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/**")
                         .permitAll()
                         // 회원가입 추가 정보 입력 API (REGISTRATION 토큰 필요 - 컨트롤러에서 TokenType 검증)
-                        .requestMatchers("/api/v1/users")
+                        .requestMatchers("/api/v1/users", "/api/v1/users/validation")
+                        .permitAll()
+                        // presigend-url 발급
+                        .requestMatchers("/api/v1/presigned-url")
                         .permitAll()
                         // 그 외 API는 인증 필요
                         .anyRequest()


### PR DESCRIPTION
# 연관된 이슈
- #78 
---

# 작업 내용
- kakaoLogin에서 PENDING 상태 회원은 handlePendingUser로 처리
- 기존 User 재활용하여 새 REGISTRATION 토큰 발급
- FE 의존 없이 BE에서 자체적으로 문제 해결
---
# 체크리스트
- [x] Spotless 적용 완료
# 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
# 기타 (선택)
