### PR TITLE
feat(user): 회원 탈퇴 API 구현 close #136

### DIFF
--- a/src/main/java/com/example/kloset_lab/clothes/repository/ClothesRepository.java
+++ b/src/main/java/com/example/kloset_lab/clothes/repository/ClothesRepository.java
@@ -2,9 +2,11 @@ package com.example.kloset_lab.clothes.repository;
 
 import com.example.kloset_lab.clothes.entity.Category;
 import com.example.kloset_lab.clothes.entity.Clothes;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -61,4 +63,14 @@ public interface ClothesRepository extends JpaRepository<Clothes, Long> {
             @Param("category") Category category,
             @Param("cursor") Long cursor,
             Pageable pageable);
+
+    /**
+     * 특정 유저의 모든 옷을 soft delete 처리
+     *
+     * @param userId 유저 ID
+     * @param deletedAt 삭제 시각
+     */
+    @Modifying
+    @Query("UPDATE Clothes c SET c.deletedAt = :deletedAt WHERE c.user.id = :userId AND c.deletedAt IS NULL")
+    void softDeleteAllByUserId(@Param("userId") Long userId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/com/example/kloset_lab/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/kloset_lab/comment/repository/CommentRepository.java
@@ -1,10 +1,12 @@
 package com.example.kloset_lab.comment.repository;
 
 import com.example.kloset_lab.comment.entity.Comment;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -67,4 +69,14 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
         GROUP BY c.parent.id
     """)
     List<Object[]> countRepliesByParentIds(@Param("parentIds") List<Long> parentIds);
+
+    /**
+     * 특정 유저의 모든 댓글을 soft delete 처리
+     *
+     * @param userId    유저 ID
+     * @param deletedAt 삭제 시각
+     */
+    @Modifying
+    @Query("UPDATE Comment c SET c.deletedAt = :deletedAt WHERE c.user.id = :userId AND c.deletedAt IS NULL")
+    void softDeleteAllByUserId(@Param("userId") Long userId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/com/example/kloset_lab/feed/repository/FeedRepository.java
+++ b/src/main/java/com/example/kloset_lab/feed/repository/FeedRepository.java
@@ -1,9 +1,11 @@
 package com.example.kloset_lab.feed.repository;
 
 import com.example.kloset_lab.feed.entity.Feed;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -36,4 +38,14 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
             ORDER BY f.id DESC
             """)
     Slice<Feed> findByUserIdAndCursor(@Param("userId") Long userId, @Param("cursor") Long cursor, Pageable pageable);
+
+    /**
+     * 특정 유저의 모든 피드를 soft delete 처리
+     *
+     * @param userId 유저 ID
+     * @param deletedAt 삭제 시각
+     */
+    @Modifying
+    @Query("UPDATE Feed f SET f.deletedAt = :deletedAt WHERE f.user.id = :userId AND f.deletedAt IS NULL")
+    void softDeleteAllByUserId(@Param("userId") Long userId, @Param("deletedAt") LocalDateTime deletedAt);
 }

--- a/src/main/java/com/example/kloset_lab/global/response/Message.java
+++ b/src/main/java/com/example/kloset_lab/global/response/Message.java
@@ -12,6 +12,7 @@ public class Message {
 
     // User
     public static final String USER_CREATED = "user_created";
+    public static final String USER_DELETED = "user_deleted";
     public static final String NICKNAME_CHECKED_UNIQUE = "nickname_checked_unique";
     public static final String NICKNAME_CHECKED_DUPLICATE = "nickname_checked_duplicate";
     public static final String BIRTH_DATE_VALID = "birth_date_valid";

--- a/src/main/java/com/example/kloset_lab/user/controller/UserController.java
+++ b/src/main/java/com/example/kloset_lab/user/controller/UserController.java
@@ -45,6 +45,19 @@ public class UserController {
     }
 
     /**
+     * 회원 탈퇴 API
+     * DELETE /api/v1/users
+     *
+     * @param userId 인증된 회원 ID
+     * @return 200 OK
+     */
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal Long userId) {
+        userService.deleteUser(userId);
+        return ApiResponses.ok(Message.USER_DELETED);
+    }
+
+    /**
      * 닉네임 유효성 검사 API
      * GET /api/v1/users/validation/nickname?nickname={nickname}
      *

--- a/src/main/java/com/example/kloset_lab/user/service/UserService.java
+++ b/src/main/java/com/example/kloset_lab/user/service/UserService.java
@@ -1,5 +1,9 @@
 package com.example.kloset_lab.user.service;
 
+import com.example.kloset_lab.auth.repository.RefreshTokenRepository;
+import com.example.kloset_lab.clothes.repository.ClothesRepository;
+import com.example.kloset_lab.comment.repository.CommentRepository;
+import com.example.kloset_lab.feed.repository.FeedRepository;
 import com.example.kloset_lab.global.exception.CustomException;
 import com.example.kloset_lab.global.exception.ErrorCode;
 import com.example.kloset_lab.global.response.Message;
@@ -12,6 +16,7 @@ import com.example.kloset_lab.user.entity.User;
 import com.example.kloset_lab.user.entity.UserProfile;
 import com.example.kloset_lab.user.repository.UserProfileRepository;
 import com.example.kloset_lab.user.repository.UserRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +32,10 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
     private final MediaFileRepository mediaFileRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final FeedRepository feedRepository;
+    private final CommentRepository commentRepository;
+    private final ClothesRepository clothesRepository;
     private final UserProfileValidationService userProfileValidationService;
     private final MediaService mediaService;
 
@@ -62,6 +71,27 @@ public class UserService {
 
         user.completeRegistration();
         userProfileRepository.save(userProfile);
+    }
+
+    /**
+     * 회원 탈퇴 처리 (soft delete)
+     * 유저와 연관된 피드, 댓글, 옷도 함께 soft delete 처리
+     *
+     * @param userId 탈퇴할 회원 ID
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        feedRepository.softDeleteAllByUserId(userId, now);
+        commentRepository.softDeleteAllByUserId(userId, now);
+        clothesRepository.softDeleteAllByUserId(userId, now);
+
+        user.softDelete();
+
+        refreshTokenRepository.deleteByUserId(userId);
     }
 
     /**


### PR DESCRIPTION
<!-- 제목은 type: subject 형태로 적어주세요 -->

## 연관된 이슈
<!-- 연관된 이슈를 적어주세요. ex) #20 [BE] 소셜 로그인 구현 -->
- #136 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 설명해주세요 -->
<!-- 엔터 쳐서 계속 작성 -->
- 회원 탈퇴 API 개발
- 회원 탈퇴 시 피드, 댓글, 옷도 함께 soft delete
- 각 Repository에 softDeleteAllByUserId() 벌크 메서드 추가
- Refresh Token 삭제 처리 포함

## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 