### PR TITLE
fix: 회원 탈퇴 시, 탈퇴회원의 댓글 수, 좋아요 수가 피드의 캐싱컬럼에 반영되지 않던 문제 해결

### DIFF
--- a/src/main/java/com/example/kloset_lab/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/example/kloset_lab/comment/repository/CommentLikeRepository.java
@@ -15,6 +15,14 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     Optional<CommentLike> findByCommentIdAndUserId(Long commentId, Long userId);
 
     /**
+     * 특정 유저가 누른 모든 댓글 좋아요 조회
+     *
+     * @param userId 유저 ID
+     * @return 댓글 좋아요 목록
+     */
+    List<CommentLike> findAllByUserId(Long userId);
+
+    /**
      * @param commentIds 댓글 ID 목록
      * @param userId 사용자 ID
      * @return 좋아요 목록

--- a/src/main/java/com/example/kloset_lab/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/kloset_lab/comment/repository/CommentRepository.java
@@ -79,4 +79,13 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("UPDATE Comment c SET c.deletedAt = :deletedAt WHERE c.user.id = :userId AND c.deletedAt IS NULL")
     void softDeleteAllByUserId(@Param("userId") Long userId, @Param("deletedAt") LocalDateTime deletedAt);
+
+    /**
+     * 특정 유저의 삭제되지 않은 모든 댓글 조회 (soft delete 전 카운트 감소용)
+     *
+     * @param userId 유저 ID
+     * @return 댓글 목록
+     */
+    @Query("SELECT c FROM Comment c WHERE c.user.id = :userId AND c.deletedAt IS NULL")
+    List<Comment> findAllActiveByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/kloset_lab/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/example/kloset_lab/feed/repository/FeedLikeRepository.java
@@ -13,6 +13,14 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
 
     Optional<FeedLike> findByFeedIdAndUserId(Long feedId, Long userId);
 
+    /**
+     * 특정 유저가 누른 모든 피드 좋아요 조회
+     *
+     * @param userId 유저 ID
+     * @return 피드 좋아요 목록
+     */
+    List<FeedLike> findAllByUserId(Long userId);
+
     void deleteByFeedIdAndUserId(Long feedId, Long userId);
 
     List<FeedLike> findByFeedIdInAndUserId(List<Long> feedIds, Long userId);

--- a/src/main/java/com/example/kloset_lab/user/controller/UserController.java
+++ b/src/main/java/com/example/kloset_lab/user/controller/UserController.java
@@ -13,6 +13,7 @@ import com.example.kloset_lab.global.response.ApiResponses;
 import com.example.kloset_lab.global.response.Message;
 import com.example.kloset_lab.global.response.PagedResponse;
 import com.example.kloset_lab.user.dto.*;
+import com.example.kloset_lab.user.service.UserLifecycleService;
 import com.example.kloset_lab.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserLifecycleService userLifecycleService;
     private final FeedService feedService;
     private final ClothesService clothesService;
 
@@ -53,7 +55,7 @@ public class UserController {
      */
     @DeleteMapping
     public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal Long userId) {
-        userService.deleteUser(userId);
+        userLifecycleService.deleteUser(userId);
         return ApiResponses.ok(Message.USER_DELETED);
     }
 

--- a/src/main/java/com/example/kloset_lab/user/service/UserLifecycleService.java
+++ b/src/main/java/com/example/kloset_lab/user/service/UserLifecycleService.java
@@ -1,0 +1,144 @@
+package com.example.kloset_lab.user.service;
+
+import com.example.kloset_lab.auth.repository.RefreshTokenRepository;
+import com.example.kloset_lab.clothes.repository.ClothesRepository;
+import com.example.kloset_lab.comment.entity.Comment;
+import com.example.kloset_lab.comment.entity.CommentLike;
+import com.example.kloset_lab.comment.repository.CommentLikeRepository;
+import com.example.kloset_lab.comment.repository.CommentRepository;
+import com.example.kloset_lab.feed.entity.Feed;
+import com.example.kloset_lab.feed.entity.FeedLike;
+import com.example.kloset_lab.feed.repository.FeedLikeRepository;
+import com.example.kloset_lab.feed.repository.FeedRepository;
+import com.example.kloset_lab.global.exception.CustomException;
+import com.example.kloset_lab.global.exception.ErrorCode;
+import com.example.kloset_lab.user.entity.User;
+import com.example.kloset_lab.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 회원 생애주기 관리 서비스 (Facade)
+ * 회원 탈퇴/복구 시 여러 도메인에 걸친 작업을 조율합니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserLifecycleService {
+
+    private final UserRepository userRepository;
+    private final FeedRepository feedRepository;
+    private final FeedLikeRepository feedLikeRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final ClothesRepository clothesRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * 회원 탈퇴 처리
+     *
+     * @param userId 탈퇴할 회원 ID
+     */
+    @Transactional
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        deleteFeedLikesAndDecrementCounts(userId);
+
+        deleteCommentLikesAndDecrementCounts(userId);
+
+        softDeleteCommentsAndDecrementFeedCounts(userId, now);
+
+        feedRepository.softDeleteAllByUserId(userId, now);
+
+        clothesRepository.softDeleteAllByUserId(userId, now);
+
+        user.softDelete();
+
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+
+    /**
+     * 피드 좋아요 삭제 및 Feed.likeCount 감소
+     * <br>
+     * 동시 탈퇴 상황: 데드락 방지를 위해 Feed ID 오름차순으로 정렬 후 처리
+     */
+    private void deleteFeedLikesAndDecrementCounts(Long userId) {
+        List<FeedLike> feedLikes = feedLikeRepository.findAllByUserId(userId);
+
+        if (feedLikes.isEmpty()) {
+            return;
+        }
+
+        Map<Long, List<FeedLike>> likesByFeedId = feedLikes.stream()
+                .collect(Collectors.groupingBy(fl -> fl.getFeed().getId()));
+
+        List<Long> sortedFeedIds = likesByFeedId.keySet().stream().sorted().toList();
+
+        for (Long feedId : sortedFeedIds) {
+            Feed feed = likesByFeedId.get(feedId).getFirst().getFeed();
+            feed.decrementLikeCount();
+        }
+
+        feedLikeRepository.deleteAll(feedLikes);
+    }
+
+    /**
+     * 댓글 좋아요 삭제 및 Comment.likeCount 감소
+     * 데드락 방지를 위해 Comment ID 오름차순으로 정렬 후 처리
+     */
+    private void deleteCommentLikesAndDecrementCounts(Long userId) {
+        List<CommentLike> commentLikes = commentLikeRepository.findAllByUserId(userId);
+
+        if (commentLikes.isEmpty()) {
+            return;
+        }
+
+        Map<Long, List<CommentLike>> likesByCommentId = commentLikes.stream()
+                .collect(Collectors.groupingBy(cl -> cl.getComment().getId()));
+
+        List<Long> sortedCommentIds =
+                likesByCommentId.keySet().stream().sorted().toList();
+
+        for (Long commentId : sortedCommentIds) {
+            Comment comment = likesByCommentId.get(commentId).getFirst().getComment();
+            comment.decrementLikeCount();
+        }
+
+        commentLikeRepository.deleteAll(commentLikes);
+    }
+
+    /**
+     * 댓글 soft delete 및 Feed.commentCount 감소
+     * 데드락 방지를 위해 Feed ID 오름차순으로 정렬 후 처리
+     */
+    private void softDeleteCommentsAndDecrementFeedCounts(Long userId, LocalDateTime deletedAt) {
+        List<Comment> comments = commentRepository.findAllActiveByUserId(userId);
+
+        if (comments.isEmpty()) {
+            return;
+        }
+
+        Map<Long, List<Comment>> commentsByFeedId =
+                comments.stream().collect(Collectors.groupingBy(c -> c.getFeed().getId()));
+
+        List<Long> sortedFeedIds = commentsByFeedId.keySet().stream().sorted().toList();
+
+        for (Long feedId : sortedFeedIds) {
+            List<Comment> feedComments = commentsByFeedId.get(feedId);
+            Feed feed = feedComments.getFirst().getFeed();
+
+            for (int i = 0; i < feedComments.size(); i++) {
+                feed.decrementCommentCount();
+            }
+        }
+
+        commentRepository.softDeleteAllByUserId(userId, deletedAt);
+    }
+}

--- a/src/main/java/com/example/kloset_lab/user/service/UserService.java
+++ b/src/main/java/com/example/kloset_lab/user/service/UserService.java
@@ -1,9 +1,5 @@
 package com.example.kloset_lab.user.service;
 
-import com.example.kloset_lab.auth.repository.RefreshTokenRepository;
-import com.example.kloset_lab.clothes.repository.ClothesRepository;
-import com.example.kloset_lab.comment.repository.CommentRepository;
-import com.example.kloset_lab.feed.repository.FeedRepository;
 import com.example.kloset_lab.global.exception.CustomException;
 import com.example.kloset_lab.global.exception.ErrorCode;
 import com.example.kloset_lab.global.response.Message;
@@ -16,7 +12,6 @@ import com.example.kloset_lab.user.entity.User;
 import com.example.kloset_lab.user.entity.UserProfile;
 import com.example.kloset_lab.user.repository.UserProfileRepository;
 import com.example.kloset_lab.user.repository.UserRepository;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,10 +27,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserProfileRepository userProfileRepository;
     private final MediaFileRepository mediaFileRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
-    private final FeedRepository feedRepository;
-    private final CommentRepository commentRepository;
-    private final ClothesRepository clothesRepository;
     private final UserProfileValidationService userProfileValidationService;
     private final MediaService mediaService;
 
@@ -71,27 +62,6 @@ public class UserService {
 
         user.completeRegistration();
         userProfileRepository.save(userProfile);
-    }
-
-    /**
-     * 회원 탈퇴 처리 (soft delete)
-     * 유저와 연관된 피드, 댓글, 옷도 함께 soft delete 처리
-     *
-     * @param userId 탈퇴할 회원 ID
-     */
-    @Transactional
-    public void deleteUser(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        LocalDateTime now = LocalDateTime.now();
-
-        feedRepository.softDeleteAllByUserId(userId, now);
-        commentRepository.softDeleteAllByUserId(userId, now);
-        clothesRepository.softDeleteAllByUserId(userId, now);
-
-        user.softDelete();
-
-        refreshTokenRepository.deleteByUserId(userId);
     }
 
     /**


### PR DESCRIPTION
<!-- 제목은 type: subject 형태로 적어주세요 -->

## 연관된 이슈
<!-- 연관된 이슈를 적어주세요. ex) #20 [BE] 소셜 로그인 구현 -->
- #164 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 설명해주세요 -->
<!-- 엔터 쳐서 계속 작성 -->
- 회원 탈퇴/(이후)복구 기능을 위한 회원 생애 주기 관리 서비스를 facade패턴으로 구현
- 동시에 발생하는 회원 탈퇴 시나리오를 고려하여, 물리 삭제 대상 레코드 순서를 오름차순 정렬로 처리하여 데드락 가능성 방지

## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 