### PR TITLE
feat: Bean Validation 예외를 ErrorCode 기반으로 통합 처리                       …

### DIFF
--- a/src/main/java/com/example/kloset_lab/feed/dto/FeedCreateRequest.java
+++ b/src/main/java/com/example/kloset_lab/feed/dto/FeedCreateRequest.java
@@ -1,5 +1,6 @@
 package com.example.kloset_lab.feed.dto;
 
+import com.example.kloset_lab.global.exception.ErrorCode;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -8,11 +9,12 @@ import java.util.List;
  * 피드 생성 요청 DTO
  *
  * @param fileIds    업로드한 파일 ID 배열 (필수, 1~5개)
- * @param content    피드 내용 (선택)
- * @param clothesIds 매핑할 옷 ID 배열 (선택)
+ * @param content    피드 내용 (선택, 최대 500자)
+ * @param clothesIds 매핑할 옷 ID 배열 (선택, 최대 10개)
  */
 public record FeedCreateRequest(
-        @NotEmpty(message = "이미지는 최소 1개 이상 필요합니다") @Size(max = 5, message = "이미지는 최대 5개까지 업로드 가능합니다")
+        @NotEmpty(message = ErrorCode.Code.MINIMUM_1_FILE_ALLOWED)
+                @Size(max = 5, message = ErrorCode.Code.MAXIMUM_5_FILES_ALLOWED)
                 List<Long> fileIds,
-        String content,
-        @Size(max = 10, message = "옷 태그는 최대 10개까지 가능합니다") List<Long> clothesIds) {}
+        @Size(max = 500, message = ErrorCode.Code.CONTENT_TOO_LONG) String content,
+        @Size(max = 10, message = ErrorCode.Code.MAXIMUM_10_CLOTHES_MAPPING_ALLOWED) List<Long> clothesIds) {}

--- a/src/main/java/com/example/kloset_lab/feed/dto/FeedUpdateRequest.java
+++ b/src/main/java/com/example/kloset_lab/feed/dto/FeedUpdateRequest.java
@@ -1,13 +1,15 @@
 package com.example.kloset_lab.feed.dto;
 
+import com.example.kloset_lab.global.exception.ErrorCode;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 /**
  * 피드 수정 요청 DTO
  *
- * @param content    피드 내용 (null이면 수정 안함)
- * @param clothesIds 매핑할 옷 ID 배열 (null이면 수정 안함, 빈 배열이면 매핑 삭제)
+ * @param content    피드 내용 (null이면 수정 안함, 최대 500자)
+ * @param clothesIds 매핑할 옷 ID 배열 (null이면 수정 안함, 빈 배열이면 매핑 삭제, 최대 10개)
  */
 public record FeedUpdateRequest(
-        String content, @Size(max = 10, message = "옷 태그는 최대 10개까지 가능합니다") List<Long> clothesIds) {}
+        @Size(max = 500, message = ErrorCode.Code.CONTENT_TOO_LONG) String content,
+        @Size(max = 10, message = ErrorCode.Code.MAXIMUM_10_CLOTHES_MAPPING_ALLOWED) List<Long> clothesIds) {}

--- a/src/main/java/com/example/kloset_lab/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/kloset_lab/global/exception/ErrorCode.java
@@ -59,10 +59,10 @@ public enum ErrorCode {
     UPLOADED_FILE_MISMATCH(HttpStatus.CONFLICT, "uploaded_file_mismatch"),
 
     // 413 Payload Too Large
-    CONTENT_TOO_LONG(HttpStatus.PAYLOAD_TOO_LARGE, "content_too_long"),
     FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "file_too_large"),
 
     // 422 Unprocessable Entity
+    CONTENT_TOO_LONG(HttpStatus.UNPROCESSABLE_ENTITY, "content_too_long"),
     EMPTY_CLOSET(HttpStatus.UNPROCESSABLE_ENTITY, "empty_closet"),
     INSUFFICIENT_ITEMS(HttpStatus.UNPROCESSABLE_ENTITY, "insufficient_items"),
     NO_MATCHED_ITEMS(HttpStatus.UNPROCESSABLE_ENTITY, "no_matched_items"),
@@ -88,5 +88,19 @@ public enum ErrorCode {
     ErrorCode(HttpStatus status, String message) {
         this.status = status;
         this.message = message;
+    }
+
+    /**
+     * Bean Validation 어노테이션 message 속성용 상수 클래스
+     * <p>
+     * 컴파일 타임 체크를 위해 ErrorCode와 동일한 이름 사용. DTO에서 ErrorCode.Code.CONTENT_TOO_LONG 형태로 참조.
+     */
+    public static class Code {
+        public static final String CONTENT_TOO_LONG = "content_too_long";
+        public static final String MINIMUM_1_FILE_ALLOWED = "minimum_1_file_allowed";
+        public static final String MAXIMUM_5_FILES_ALLOWED = "maximum_5_files_allowed";
+        public static final String MAXIMUM_10_CLOTHES_MAPPING_ALLOWED = "maximum_10_clothes_mapping_allowed";
+
+        private Code() {}
     }
 }

--- a/src/main/java/com/example/kloset_lab/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/kloset_lab/global/exception/GlobalExceptionHandler.java
@@ -2,14 +2,58 @@ package com.example.kloset_lab.global.exception;
 
 import com.example.kloset_lab.global.response.ApiResponse;
 import com.example.kloset_lab.global.response.ApiResponses;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /**
+     * Bean Validation 실패 시 ErrorCode 기반 응답 반환
+     *
+     * @param e MethodArgumentNotValidException
+     * @return ErrorCode에 매핑된 에러 응답
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        FieldError firstError = e.getBindingResult().getFieldError();
+        if (firstError == null) {
+            return ApiResponses.error(ErrorCode.INVALID_REQUEST);
+        }
+
+        String messageValue = firstError.getDefaultMessage();
+        ErrorCode errorCode = findErrorCodeByMessage(messageValue).orElseGet(() -> {
+            log.warn("Unknown error code in validation: {}", messageValue);
+            return ErrorCode.INVALID_REQUEST;
+        });
+
+        log.warn("Validation failed: field={}, errorCode={}", firstError.getField(), errorCode);
+        return ApiResponses.error(errorCode);
+    }
+
+    /**
+     * message 값으로 ErrorCode 조회
+     *
+     * @param message ErrorCode의 message 필드 값 (snake_case)
+     * @return 매칭되는 ErrorCode
+     */
+    private Optional<ErrorCode> findErrorCodeByMessage(String message) {
+        if (message == null) {
+            return Optional.empty();
+        }
+        for (ErrorCode code : ErrorCode.values()) {
+            if (code.getMessage().equals(message)) {
+                return Optional.of(code);
+            }
+        }
+        return Optional.empty();
+    }
 
     @ExceptionHandler(InvalidTokenException.class)
     public ResponseEntity<ApiResponse<Void>> handleInvalidTokenException(InvalidTokenException e) {


### PR DESCRIPTION
<!-- 제목은 type: subject 형태로 적어주세요 -->

## 연관된 이슈
<!-- 연관된 이슈를 적어주세요. ex) #20 [BE] 소셜 로그인 구현 -->
- #165 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 설명해주세요 -->
<!-- 엔터 쳐서 계속 작성 -->
- ErrorCode 내부에 Code 클래스 추가 (상수값은 message와 동일한 snake_case)           
- FeedCreateRequest, FeedUpdateRequest에 ErrorCode.Code 상수 적용              
- GlobalExceptionHandler에 MethodArgumentNotValidException 핸들러 추가                       
- 글자 수 초과 시 422 content_too_long 응답 반환
 

## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 