### PR TITLE
fix: WebSocket 연결 실패 수정

### DIFF
--- a/src/main/java/com/example/kloset_lab/global/config/WebSocketConfig.java
+++ b/src/main/java/com/example/kloset_lab/global/config/WebSocketConfig.java
@@ -18,7 +18,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
     }
 
     @Override
@@ -26,7 +26,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 클라이언트 → 서버 메시지 prefix
         registry.setApplicationDestinationPrefixes("/app");
         // 서버 → 클라이언트 브로커 prefix
-        registry.enableSimpleBroker("/topic", "/user/queue");
+        // heartbeat: ALB idle timeout(60s) 이내로 유지하기 위해 30s 주기 설정
+        registry.enableSimpleBroker("/topic", "/user/queue")
+                .setHeartbeatValue(new long[] {30000, 30000});
         // 특정 사용자 목적지 prefix
         registry.setUserDestinationPrefix("/user");
     }


### PR DESCRIPTION
<!-- 제목은 type: subject 형태로 적어주세요 -->
## 연관된 이슈
<!-- 연관된 이슈를 적어주세요. ex) #20 [BE] 소셜 로그인 구현 -->
- #248 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 설명해주세요 -->
<!-- 엔터 쳐서 계속 작성 -->
- SockJS 제거 및 heartbeat 설정
- withSockJS() 제거: FE가 순수 WebSocket(STOMP) 클라이언트를 사용하므로 SockJS 프로토콜을 기대하는 서버 설정과 불일치로 연결이 실패하던 문제 해결
- SimpleBroker heartbeat 30s 설정: ALB idle timeout(60s) 초과로 인한 WebSocket 강제 종료 방지


## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 