### PR TITLE
chore: 로깅 필터 로그 출력 순서 개선

### DIFF
--- a/src/main/java/com/example/kloset_lab/global/config/LoggingFilter.java
+++ b/src/main/java/com/example/kloset_lab/global/config/LoggingFilter.java
@@ -27,10 +27,13 @@ public class LoggingFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
             return;
         }
+        log.info("Request: {} {}", method, uri);
         long start = System.currentTimeMillis();
-        filterChain.doFilter(request, response);
-        long time = System.currentTimeMillis() - start;
-
-        log.info("Request: {} {} → {} ({}ms)", method, uri, response.getStatus(), time);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            long time = System.currentTimeMillis() - start;
+            log.info("Response: {} {} → {} ({}ms)", method, uri, response.getStatus(), time);
+        }
     }
 }


### PR DESCRIPTION
<!-- 제목은 type: subject 형태로 적어주세요 -->

## 연관된 이슈
<!-- 연관된 이슈를 적어주세요. ex) #20 [BE] 소셜 로그인 구현 -->
- #256 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 설명해주세요 -->
<!-- 엔터 쳐서 계속 작성 -->
- **로깅 필터 순서가 아니라, log 출력문이 dofilter 메서드 뒤에 있던 부분이 문제였음.**
- log.info를 filterChain.doFilter() 호출 전으로 이동하여 API 요청 정보가 먼저 출력되도록 변경
- 요청 수신(Request)과 응답 완료(Response) 로그를 분리하여 가독성 향상
- try-finally로 예외 발생 시에도 응답 로그가 누락되지 않도록 수정

## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [] 테스트 통과 완료
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 