### PR TITLE
fix: WebSocket Simple Broker prefix를 /user/queue에서 /queue로 수정

### DIFF
--- a/src/main/java/com/example/kloset_lab/global/config/WebSocketConfig.java
+++ b/src/main/java/com/example/kloset_lab/global/config/WebSocketConfig.java
@@ -34,8 +34,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         // 클라이언트 → 서버 메시지 prefix
         registry.setApplicationDestinationPrefixes("/app");
-        // 서버 → 클라이언트 브로커 prefix
-        registry.enableSimpleBroker("/topic", "/user/queue")
+        // 브로커 destination prefix: /topic (브로드캐스트), /queue (user-specific queue 내부 변환 경로)
+        registry.enableSimpleBroker("/topic", "/queue")
                 .setHeartbeatValue(new long[] {30000, 30000})
                 .setTaskScheduler(messageBrokerTaskScheduler);
         // 특정 사용자 목적지 prefix


### PR DESCRIPTION
<!-- 제목은 type: subject 형태로 적어주세요 -->

## 연관된 이슈
<!-- 연관된 이슈를 적어주세요. ex) #20 [BE] 소셜 로그인 구현 -->
- #259 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 설명해주세요 -->
<!-- 엔터 쳐서 계속 작성 -->
- UserDestinationMessageHandler가 /user/queue/chat-room-updates 구독을 내부적으로 /queue/chat-room-updates-{sessionId}로 변환하는데, 브로커에 /queue prefix가 등록되지 않아 메시지가 드롭되던 문제 수정


## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 