### PR TITLE
fix: 채팅 이미지 메시지 전송 시 INVALID_REQUEST 오류 수정

### DIFF
--- a/src/main/java/com/example/kloset_lab/chat/service/ChatMessageService.java
+++ b/src/main/java/com/example/kloset_lab/chat/service/ChatMessageService.java
@@ -17,15 +17,16 @@ import com.example.kloset_lab.chat.repository.ChatRoomRepository;
 import com.example.kloset_lab.feed.repository.FeedRepository;
 import com.example.kloset_lab.global.exception.CustomException;
 import com.example.kloset_lab.global.exception.ErrorCode;
-import com.example.kloset_lab.media.entity.FileStatus;
 import com.example.kloset_lab.media.entity.MediaFile;
 import com.example.kloset_lab.media.entity.Purpose;
 import com.example.kloset_lab.media.repository.MediaFileRepository;
+import com.example.kloset_lab.media.service.MediaService;
 import com.example.kloset_lab.user.entity.UserProfile;
 import com.example.kloset_lab.user.repository.UserProfileRepository;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +44,7 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final MediaFileRepository mediaFileRepository;
+    private final MediaService mediaService;
     private final FeedRepository feedRepository;
     private final UserProfileRepository userProfileRepository;
     private final CdnProperties cdnProperties;
@@ -157,7 +159,12 @@ public class ChatMessageService {
         }
     }
 
-    /** 이미지 타입 메시지의 media_file 검증 및 ChatImage 목록 생성 */
+    /**
+     * 이미지 타입 메시지의 media_file 검증(PENDING→UPLOADED 전환) 및 ChatImage 목록 생성
+     *
+     * <p>소유자·purpose·S3 존재 확인 후 파일 상태를 PENDING→UPLOADED로 전환한다.
+     * MongoDB 저장 실패 시 @Transactional 롤백으로 상태가 PENDING으로 자동 복원된다.
+     */
     private List<ChatImage> validateAndBuildImages(Long userId, ChatSendRequest req) {
         if (!ChatConstants.MSG_TYPE_IMAGE.equals(req.type())
                 || req.mediaFileIds() == null
@@ -165,30 +172,19 @@ public class ChatMessageService {
             return List.of();
         }
 
-        if (req.mediaFileIds().size() > Purpose.CHAT.getMaxCount()) {
-            throw new CustomException(ErrorCode.TOO_MANY_FILES);
-        }
+        // 소유자·purpose·S3 존재 확인 후 PENDING → UPLOADED 전환
+        // (TOO_MANY_FILES, FILE_NOT_FOUND, FILE_ACCESS_DENIED, UPLOADED_FILE_MISMATCH, NOT_PENDING_STATE 예외 포함)
+        mediaService.confirmFileUpload(userId, Purpose.CHAT, req.mediaFileIds());
+
+        Map<Long, MediaFile> fileMap = mediaFileRepository.findAllById(req.mediaFileIds()).stream()
+                .collect(Collectors.toMap(MediaFile::getId, f -> f));
 
         List<ChatImage> chatImages = new ArrayList<>();
         for (int i = 0; i < req.mediaFileIds().size(); i++) {
             Long mediaFileId = req.mediaFileIds().get(i);
-            MediaFile mediaFile = mediaFileRepository
-                    .findById(mediaFileId)
-                    .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
-
-            if (!mediaFile.getUser().getId().equals(userId)) {
-                throw new CustomException(ErrorCode.FILE_ACCESS_DENIED);
-            }
-            if (mediaFile.getPurpose() != Purpose.CHAT) {
-                throw new CustomException(ErrorCode.INVALID_REQUEST);
-            }
-            if (mediaFile.getStatus() != FileStatus.UPLOADED) {
-                throw new CustomException(ErrorCode.INVALID_REQUEST);
-            }
-
             chatImages.add(ChatImage.builder()
                     .mediaFileId(mediaFileId)
-                    .objectKey(mediaFile.getObjectKey())
+                    .objectKey(fileMap.get(mediaFileId).getObjectKey())
                     .displayOrder(i + 1)
                     .build());
         }

--- a/src/main/java/com/example/kloset_lab/media/service/MediaService.java
+++ b/src/main/java/com/example/kloset_lab/media/service/MediaService.java
@@ -84,7 +84,6 @@ public class MediaService {
         }
         mediaFileList.forEach(file -> storageService.validateUpload(file.getObjectKey(), file.getFileType()));
         mediaFileList.forEach(MediaFile::updateFileStatus);
-        mediaFileRepository.saveAll(mediaFileList);
     }
 
     public List<String> getFileFullUrls(List<Long> fileIdList) {

--- a/src/test/java/com/example/kloset_lab/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/example/kloset_lab/chat/service/ChatMessageServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
 
 import com.example.kloset_lab.chat.config.CdnProperties;
@@ -32,10 +33,10 @@ import com.example.kloset_lab.feed.repository.FeedRepository;
 import com.example.kloset_lab.global.annotation.ServiceTest;
 import com.example.kloset_lab.global.exception.CustomException;
 import com.example.kloset_lab.global.exception.ErrorCode;
-import com.example.kloset_lab.media.entity.FileStatus;
 import com.example.kloset_lab.media.entity.MediaFile;
 import com.example.kloset_lab.media.entity.Purpose;
 import com.example.kloset_lab.media.repository.MediaFileRepository;
+import com.example.kloset_lab.media.service.MediaService;
 import com.example.kloset_lab.user.entity.User;
 import com.example.kloset_lab.user.entity.UserProfile;
 import com.example.kloset_lab.user.repository.UserProfileRepository;
@@ -49,6 +50,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ServiceTest
 @DisplayName("ChatMessageService 단위 테스트")
@@ -65,6 +67,9 @@ class ChatMessageServiceTest {
 
     @Mock
     private MediaFileRepository mediaFileRepository;
+
+    @Mock
+    private MediaService mediaService;
 
     @Mock
     private FeedRepository feedRepository;
@@ -198,6 +203,9 @@ class ChatMessageServiceTest {
         @DisplayName("IMAGE 파일이 maxCount(3)를 초과하면 TOO_MANY_FILES 예외")
         void IMAGE_파일_수_초과_예외() {
             givenParticipantAndRoomFound();
+            willThrow(new CustomException(ErrorCode.TOO_MANY_FILES))
+                    .given(mediaService)
+                    .confirmFileUpload(USER_ID, Purpose.CHAT, List.of(1L, 2L, 3L, 4L));
 
             assertCustomException(
                     () -> chatMessageService.sendMessage(USER_ID, ROOM_ID, sendImageRequest(List.of(1L, 2L, 3L, 4L))),
@@ -208,7 +216,9 @@ class ChatMessageServiceTest {
         @DisplayName("IMAGE 파일을 찾지 못하면 FILE_NOT_FOUND 예외")
         void IMAGE_mediaFile_없음_예외() {
             givenParticipantAndRoomFound();
-            given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.empty());
+            willThrow(new CustomException(ErrorCode.FILE_NOT_FOUND))
+                    .given(mediaService)
+                    .confirmFileUpload(USER_ID, Purpose.CHAT, List.of(MEDIA_FILE_ID));
 
             assertCustomException(
                     () -> chatMessageService.sendMessage(USER_ID, ROOM_ID, sendImageRequest(List.of(MEDIA_FILE_ID))),
@@ -218,10 +228,10 @@ class ChatMessageServiceTest {
         @Test
         @DisplayName("IMAGE 파일의 소유자가 다르면 FILE_ACCESS_DENIED 예외")
         void IMAGE_타_사용자_파일_예외() {
-            User otherUser = ChatFixture.chatUser(99L);
-            MediaFile file = ChatFixture.uploadedChatMediaFile(otherUser);
             givenParticipantAndRoomFound();
-            given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(file));
+            willThrow(new CustomException(ErrorCode.FILE_ACCESS_DENIED))
+                    .given(mediaService)
+                    .confirmFileUpload(USER_ID, Purpose.CHAT, List.of(MEDIA_FILE_ID));
 
             assertCustomException(
                     () -> chatMessageService.sendMessage(USER_ID, ROOM_ID, sendImageRequest(List.of(MEDIA_FILE_ID))),
@@ -229,29 +239,29 @@ class ChatMessageServiceTest {
         }
 
         @Test
-        @DisplayName("IMAGE 파일 purpose가 CHAT이 아니면 INVALID_REQUEST 예외")
+        @DisplayName("IMAGE 파일 purpose가 CHAT이 아니면 UPLOADED_FILE_MISMATCH 예외")
         void IMAGE_파일_purpose_불일치_예외() {
-            User user = ChatFixture.chatUser(USER_ID);
-            MediaFile file = ChatFixture.mediaFileWith(user, Purpose.FEED, FileStatus.UPLOADED);
             givenParticipantAndRoomFound();
-            given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(file));
+            willThrow(new CustomException(ErrorCode.UPLOADED_FILE_MISMATCH))
+                    .given(mediaService)
+                    .confirmFileUpload(USER_ID, Purpose.CHAT, List.of(MEDIA_FILE_ID));
 
             assertCustomException(
                     () -> chatMessageService.sendMessage(USER_ID, ROOM_ID, sendImageRequest(List.of(MEDIA_FILE_ID))),
-                    ErrorCode.INVALID_REQUEST);
+                    ErrorCode.UPLOADED_FILE_MISMATCH);
         }
 
         @Test
-        @DisplayName("IMAGE 파일 status가 UPLOADED가 아니면 INVALID_REQUEST 예외")
-        void IMAGE_파일_status_PENDING_예외() {
-            User user = ChatFixture.chatUser(USER_ID);
-            MediaFile file = ChatFixture.mediaFileWith(user, Purpose.CHAT, FileStatus.PENDING);
+        @DisplayName("IMAGE 파일이 이미 UPLOADED 상태이면 NOT_PENDING_STATE 예외")
+        void IMAGE_파일_이미_UPLOADED_NOT_PENDING_STATE_예외() {
             givenParticipantAndRoomFound();
-            given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(file));
+            willThrow(new CustomException(ErrorCode.NOT_PENDING_STATE))
+                    .given(mediaService)
+                    .confirmFileUpload(USER_ID, Purpose.CHAT, List.of(MEDIA_FILE_ID));
 
             assertCustomException(
                     () -> chatMessageService.sendMessage(USER_ID, ROOM_ID, sendImageRequest(List.of(MEDIA_FILE_ID))),
-                    ErrorCode.INVALID_REQUEST);
+                    ErrorCode.NOT_PENDING_STATE);
         }
 
         @Test
@@ -291,8 +301,9 @@ class ChatMessageServiceTest {
         void IMAGE_정상_전송() {
             User user = ChatFixture.chatUser(USER_ID);
             MediaFile file = ChatFixture.uploadedChatMediaFile(user);
+            ReflectionTestUtils.setField(file, "id", MEDIA_FILE_ID);
             givenParticipantAndRoomFound();
-            given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(file));
+            given(mediaFileRepository.findAllById(List.of(MEDIA_FILE_ID))).willReturn(List.of(file));
             given(cdnProperties.getBaseUrl()).willReturn("https://cdn.test.com");
             given(userProfileRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
             given(chatParticipantRepository.findByRoomId(ROOM_ID)).willReturn(List.of(givenParticipant()));
@@ -386,8 +397,9 @@ class ChatMessageServiceTest {
         void IMAGE_이벤트_페이로드() {
             User user = ChatFixture.chatUser(USER_ID);
             MediaFile file = ChatFixture.uploadedChatMediaFile(user);
+            ReflectionTestUtils.setField(file, "id", MEDIA_FILE_ID);
             givenParticipantAndRoomFound();
-            given(mediaFileRepository.findById(MEDIA_FILE_ID)).willReturn(Optional.of(file));
+            given(mediaFileRepository.findAllById(List.of(MEDIA_FILE_ID))).willReturn(List.of(file));
             given(cdnProperties.getBaseUrl()).willReturn("https://cdn.test.com");
             given(userProfileRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
             given(chatParticipantRepository.findByRoomId(ROOM_ID)).willReturn(List.of(givenParticipant()));


### PR DESCRIPTION
<!-- 제목은 type: subject 형태로 적어주세요 -->

## 연관된 이슈
<!-- 연관된 이슈를 적어주세요. ex) #20 [BE] 소셜 로그인 구현 -->
- #259 

## 작업 내용
<!-- 해당 PR에서 작업한 내용을 설명해주세요 -->
<!-- 엔터 쳐서 계속 작성 -->
- presigned-url 발급 후 파일 상태가 PENDING인 채로 UPLOADED 여부를 검증하여, 항상 INVALID_REQUEST가 반환되던 문제 수정.                                       
- validateAndBuildImages에서 수동 검증 루프를 제거하고, MediaService.confirmFileUpload()를 위임 호출하여 전송 시점에 PENDING → UPLOADED 전환과 소유자·purpose·S3 검증을 일괄 처리하도록 변경.
- MongoDB 저장 실패 시 @Transactional 롤백으로 파일 상태가 자동 복원되어 재전송 가능.
- ChatMessageService: MediaService 주입, validateAndBuildImages 위임 방식으로 교체
- ChatMessageServiceTest: confirmFileUpload 모킹 방식으로 테스트 케이스 갱신, purpose 불일치 예외 코드 INVALID_REQUEST → UPLOADED_FILE_MISMATCH 반영, PENDING 상태 예외 케이스를 이미 UPLOADED 상태의 NOT_PENDING_STATE로 교체
  
- MediaService.confirmFileUpload 메서드에서, 불필요한 마지막줄 saveAll 메서드 호출 제거 (더티체킹으로 인해 추가호출 불필요)


## 체크리스트
<!-- pr 날리기 전 확인해야할 사항 -->
<!-- 확인 후 꼭 x를 넣어주세요.(대문자 가능) ex) [x] -->
- [x] 테스트 통과 완료
- [x] Spotless 적용 완료

## 코드 리뷰시 팀원들이 특별히 확인해줬으면 하는 사항
<!-- 엔터 쳐서 계속 작성 -->
- 

## 기타 (선택)
<!-- 엔터 쳐서 계속 작성 -->
- 